### PR TITLE
Fix entry parsing for GT, LT, GE, etc.

### DIFF
--- a/nudel/core.py
+++ b/nudel/core.py
@@ -308,8 +308,8 @@ class Record(BaseRecord):
                 return
         for abbr in ["GT", "LT", "GE", "LE", "AP", "CA", "SY"]:
             if f" {abbr} " in entry:
-                quant, quant, value = entry.split(" ", maxsplit=2)
-                self.prop[quant.strip()] = f"{value.strip()} {quant}"
+                quant, abbr, value = entry.split(" ", maxsplit=2)
+                self.prop[quant.strip()] = f"{value.strip()} {abbr}"
                 return
         if entry[-1] == "?":
             self.prop[entry[:-1]] = "?"

--- a/nudel/util.py
+++ b/nudel/util.py
@@ -454,11 +454,11 @@ class Quantity:
         (?:\s*)
         (?P<chars>(?:[MUNPFA]?S|[KM]?EV|[UM]?B|STABLE|WEAK|[YDHM])?)
         (?:\s*)
-        (?P<limit>(?:[LG][TE]|AP|CA|SY)?)
-        (?:\s*)
         (?P<unc>(?:\s[\d∞]+)?)
         (?P<unc_pm>(?:\+[\d∞]+\s?-[\d∞]+)?)
         (?P<unc_mp>(?:-[\d∞]+\s?\+[\d∞]+)?)
+        (?:\s*)
+        (?P<limit>(?:[LG][TE]|AP|CA|SY)?)
         (?P<comment>(?:\s[a-z][a-zA-Z0-9,.;\s]+)?)
         $""",
         re.X,

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -969,6 +969,15 @@ def cmp_nan_safe(a, b):
             },
             "~ 4939.8 + X",
         ],
+        [
+            "45 15 LE",
+            {
+                "pm": 15,
+                "upper_bound": 45.0,
+                "upper_bound_inclusive": True,
+            },
+            "≤ 45(15)",
+        ],
     ],
 )
 def test_quantity(quantity, mod_dict, printed):


### PR DESCRIPTION
https://github.com/op3/nudel/blob/93e6f3611981ecc31b144c94d44d2164022e34e7/nudel/core.py#L309-L313

The `quant, quant, value = ...` line appears to be a mistake. It assigns the value of `abbr` to `quant`, which produces incorrect results for some nuclides:
```py
# main.py
from nudel import Nuclide
nuclide = Nuclide(186, 83) # Bi-186
for level in nuclide.adopted_levels.levels:
    print(level.decay_ratio)
```
```
# ensdf.186 lines 18644-18645
186BI  L 0.0         (3+)              14.8 MS    8                             
186BI2 L %A AP 95.5 $ %EC+%B+ AP 4.5  $%EC+%B+SF AP 0.02                 
# lines 18654-18655
186BI  L 0.0+X       (10-)             9.8 MS     4                          M  
186BI2 L %A AP 100  $ %EC+%B+=?                                                 
```
```
$ python3 main.py
{}
{'EC+%B+': <nan % ?>}
```

This PR changes this behavior to use `abbr` instead of `quant`:
```
$ python3 main.py
{'A': <~ 95.5 %>, 'EC+%B+': <~ 4.5 %>, 'EC+%B+SF': <~ 0.02 %>}
{'A': <~ 100 %>, 'EC+%B+': <nan % ?>}
```
If I've misunderstood something, let me know. Thanks for making such an awesome library!