### PR TITLE
Add CI for running tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,62 @@
+# This is a basic workflow to help you get started with Actions
+name: CI 
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+# Store environment variables
+env:
+  ENSDF_PATH: "/tmp/ensdf"
+  ENSDF_ARCHIVE: "ensdf_250902.zip"
+  ENSDF_URL: "https://www.nndc.bnl.gov/ensdfarchivals/distributions/dist25/ensdf_250902.zip"
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # Job "test"
+  test:
+
+    name: Testing with Python ${{matrix.python-version}} on ${{matrix.os}}
+
+    # Test on still-supported LTS and latest ubuntu with lowest and latest supported Python version
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.10", "3.x"]
+
+    runs-on: ${{matrix.os}}
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v5
+ 
+      # Setup an isolated Python env
+      - name: Setup python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{matrix.python-version}}
+      
+      # Just make sure we are running on latest pip
+      - name: Dependency installation
+        run: |
+          pip install --upgrade pip
+          wget $ENSDF_URL
+          mkdir $ENSDF_PATH
+          unzip $ENSDF_ARCHIVE -d $ENSDF_PATH
+      
+      # Install with test dependencies
+      - name: Package installation
+        run: pip install .[test]
+
+      # Run the test
+      - name: Testing on ${{github.head_ref || github.ref_name}}
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # 🍝 nudel – Nuclear Data Extraction Library
 
 [![License](https://img.shields.io/badge/License-GPL%20v3+-blue.svg)](COPYING)
+[![CI](https://github.com/op3/nudel/actions/workflows/main.yml/badge.svg)](https://github.com/op3/nudel/actions/workflows/main.yml)
 
 Nudel is a parser for the Evaluated Nuclear Structure Data File (ENSDF) format implemented in Python.
 
@@ -26,7 +27,7 @@ Alternatively, you can set `$ENSDF_PATH` to point to a different directory for t
 
 ## Requirements
 
-- python>=3.7
+- python>=3.10
 - pytest (*optional, only for unit tests*)
 - pytest-cov (*optional, only for unit tests*)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = {attr = "nudel.__version__"}
 [project]
 name = "nudel"
 dynamic = ["version"]
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 
 authors = [
   {name = "Oliver Papst", email = "opapst@ikp.tu-darmstadt.de"}
@@ -42,13 +42,10 @@ classifiers = [
   "Operating System :: POSIX :: Linux",
   "Operating System :: UNIX",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.7",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Scientific/Engineering",
   "Topic :: Scientific/Engineering :: Physics"
 ]


### PR DESCRIPTION
This PR adds CI for running the tests via the GitHub actions feature.

The configuration for the actions is located in `.github/workflows/main.yml`.
The action checks out the repo, pulls & unzips the latest ENSDF archive, and installs `nudel`, all inside a GH actions runner.
The action runs `pytest` for pushes and pull-request to `master`, for Python 3.10 as well as the latest stable version, on Ubuntu 22.04 and latest runners.

Additionally, the minimum Python version requirement is increased to 3.10 (from 3.7) due to some typing-related implementations in `nudel` (e.g. ["| operation for 'type' and 'NoneType'"](https://github.com/op3/nudel/blob/master/nudel/util.py#L339) only being supported from Python 3.10 onwards.

Finally, the outcome of CI is displayed in a badge in the README.